### PR TITLE
Add %{dist} (i.e. "el6") to Release

### DIFF
--- a/zookeeper.spec
+++ b/zookeeper.spec
@@ -8,7 +8,7 @@
 Summary: ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
 Name: zookeeper
 Version: %{version}
-Release: %{build_number}
+Release: %{build_number}%{?dist}
 License: Apache License, Version 2.0
 Group: Applications/Databases
 URL: http://zookeper.apache.org/


### PR DESCRIPTION
This makes a RPM be end up like this `zookeeper-3.4.9-1.el6.x86_64.rpm`, instead of `zookeeper-3.4.9-1.x86_64.rpm`. Good for differentiating between different target systems (RHEL 7 vs 6 for example).
